### PR TITLE
fix: improve error reporting when port is in use

### DIFF
--- a/main/main.go
+++ b/main/main.go
@@ -58,7 +58,8 @@ func main() {
 
 	nl, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {
-		panic(err)
+		fmt.Fprintf(os.Stderr, "Cannot start the webserver: %s\n", err.Error())
+		os.Exit(4)
 	}
 
 	go func() {


### PR DESCRIPTION
Before this change, when we could not start listening on webserver's TCP port, the binary produced by GoReleaser would abort with no meaningful error report:

```
❯ ./build/saturn/l2node-darwin-arm64/saturn-l2
[1]    16654 killed     ./build/saturn/l2node-darwin-arm64/saturn-l2
```

In this commit, I am reworking error handling to print the error to stderr and exit the process with a non-zero exit code via `os.Exit`.
