### PR TITLE
main: remove infinite loop

### DIFF
--- a/main/main.go
+++ b/main/main.go
@@ -65,17 +65,12 @@ func main() {
 		os.Exit(4)
 	}
 
-	go func() {
-		if err := srv.Serve(nl); err != http.ErrServerClosed {
-			panic(err)
-		}
-	}()
-
 	port = nl.Addr().(*net.TCPAddr).Port
 	fmt.Println("Server listening on", nl.Addr())
 	fmt.Printf("WebUI: http://localhost:%d/webui\n", port)
-	for {
 
+	if err := srv.Serve(nl); err != http.ErrServerClosed {
+		panic(err)
 	}
 }
 


### PR DESCRIPTION
Rework the node to run the webui HTTP handler in the main thread and remove the infinite loop that was causing 100% CPU load.

/cc @juliangruber